### PR TITLE
1.6 version bump

### DIFF
--- a/rpm/jq-1.6-r3-never-bundle-oniguruma.patch
+++ b/rpm/jq-1.6-r3-never-bundle-oniguruma.patch
@@ -1,0 +1,27 @@
+diff --git a/Makefile.am b/Makefile.am
+index 6344b4e..86d968e 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -47,7 +47,7 @@ AM_YFLAGS = --warnings=all -d
+ 
+ lib_LTLIBRARIES = libjq.la
+ libjq_la_SOURCES = ${LIBJQ_SRC}
+-libjq_la_LIBADD = -lm
++libjq_la_LIBADD = -lm $(onig_LIBS)
+ libjq_la_LDFLAGS = $(onig_LDFLAGS) -export-symbols-regex '^j[qv]_' -version-info 1:4:0
+ 
+ if WIN32
+diff --git a/configure.ac b/configure.ac
+index 280694c..d96026e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -249,6 +249,9 @@ AS_IF([test "x$with_oniguruma" != xno], [
+           onig_CFLAGS="-I${with_oniguruma}/include"
+           onig_LDFLAGS="-L${with_oniguruma}/lib"
+       ])
++   ], [
++	   # with_oniguruma == yes
++	   PKG_CHECK_MODULES([onig], [oniguruma])
+    ])
+    AS_IF([test "x$build_oniguruma" = xno], [
+        # check for ONIGURUMA library, either in /usr or where requested

--- a/rpm/jq-1.6-runpath.patch
+++ b/rpm/jq-1.6-runpath.patch
@@ -1,0 +1,17 @@
+diff --git a/configure.ac b/configure.ac
+index 280694c..7227c9d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -280,4 +280,11 @@ AC_SUBST([BUNDLER], ["$bundle_cmd"])
+ AC_CONFIG_MACRO_DIR([config/m4])
+ AC_CONFIG_FILES([Makefile])
+ AC_OUTPUT
+-
++AC_ARG_ENABLE([rpathhack],
++	[AC_HELP_STRING([--enable-rpathhack], [patch libtool to remove RPATH])],
++	[
++AC_MSG_RESULT([patching libtool to fix rpath])
++sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
++sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
++	],
++	[])

--- a/rpm/jq-1.6-segfault-fix.patch
+++ b/rpm/jq-1.6-segfault-fix.patch
@@ -1,0 +1,22 @@
+From a1f1231a73c221155d539a281181ef37f874869d Mon Sep 17 00:00:00 2001
+From: William Langford <wlangfor@gmail.com>
+Date: Tue, 20 Nov 2018 09:58:25 -0500
+Subject: [PATCH] Add missing jv_copy when printing with -ar
+
+---
+ src/main.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/main.c b/src/main.c
+index b154689e..61ae43f9 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -168,7 +168,7 @@ static int process(jq_state *jq, jv value, int flags, int dumpopts) {
+   while (jv_is_valid(result = jq_next(jq))) {
+     if ((options & RAW_OUTPUT) && jv_get_kind(result) == JV_KIND_STRING) {
+       if (options & ASCII_OUTPUT) {
+-        jv_dumpf(result, stdout, JV_PRINT_ASCII);
++        jv_dumpf(jv_copy(result), stdout, JV_PRINT_ASCII);
+       } else {
+         fwrite(jv_string_value(result), 1, jv_string_length_bytes(jv_copy(result)), stdout);
+       }

--- a/rpm/jq.spec
+++ b/rpm/jq.spec
@@ -1,6 +1,6 @@
 Summary: lightweight and flexible command-line JSON processor
 Name: jq
-Version: 1.5
+Version: 1.6
 Release: 1%{?dist}
 License: MIT
 Group: System/Utilities
@@ -9,7 +9,11 @@ URL: https://stedolan.github.io/jq/
 Source: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
+Patch0:     jq-1.6-r3-never-bundle-oniguruma.patch
+Patch1:     jq-1.6-runpath.patch
+Patch2:     jq-1.6-segfault-fix.patch
 BuildRequires: gcc flex bison libtool autoconf
+BuildRequires:  pkgconfig(oniguruma)
 
 %description
 jq is a lightweight and flexible command-line JSON processor.
@@ -18,13 +22,30 @@ jq is a lightweight and flexible command-line JSON processor.
 Summary: JQ development headers
 Group: Development/Libraries
 Requires: %{name} = %{version}
+Requires:   %{name}-libs = %{version}
 
 %description devel
 This package provides headers for development
 
+%package libs
+Summary:    Libraries for %{name}
+Group:      Development/Libraries
+Requires(post): /sbin/ldconfig
+Requires(postun): /sbin/ldconfig
+
+%description libs
+%{summary}.
+
+
 %prep
 %setup -q -n %{name}-%{version}/jq
 
+# jq-1.6-r3-never-bundle-oniguruma.patch
+%patch0 -p1
+# jq-1.6-runpath.patch
+%patch1 -p1
+# jq-1.6-segfault-fix.patch
+%patch2 -p1
 %build
 %{__make} clean || true
 
@@ -32,7 +53,11 @@ autoreconf -fi
 
 CFLAGS="$CFLAGS -fPIC"
 CXXFLAGS="$CXXFLAGS -fPIC"
-%configure --disable-static
+%configure --disable-static \
+    --disable-maintainer-mode \
+    --enable-devel \
+    --disable-valgrind \
+    --disable-docs \
 
 %{__make} %{?_smp_mflags}
 
@@ -40,30 +65,37 @@ CXXFLAGS="$CXXFLAGS -fPIC"
 %{__rm} -rf %{buildroot}
 %{__make} install DESTDIR=%{buildroot}
 
-%clean
-%{__rm} -rf %{buildroot}
+rm -f %{buildroot}%{_docdir}/%{name}/README
+rm -f %{buildroot}%{_docdir}/%{name}/COPYING
+rm -f %{buildroot}%{_docdir}/%{name}/AUTHORS
+rm -rf %{buildroot}%{_mandir}
 
-%pre
+%post libs -p /sbin/ldconfig
 
-%post -n jq -p /sbin/ldconfig
+%postun libs -p /sbin/ldconfig
 
-%postun -n jq -p /sbin/ldconfig
-
-
-%files
 %files
 %defattr(-, root, root, 0755)
+%license COPYING
+%{_docdir}/%{name}/README.md
 %{_bindir}/jq
-%{_libdir}/libjq.so*
 
 %files devel
 %defattr(-, root, root, 0755)
-%{_includedir}/jq.h
-%{_includedir}/jv.h
-%{_libdir}/libjq.la
-%{_mandir}/man1/*
-%{_datadir}/doc/jq
+%{_includedir}/*.h
+%{_libdir}/*.a
+%{_libdir}/lib*.so
+#%%{_mandir}/man1/*
+#%%{_datadir}/doc/jq
+
+%files libs
+%defattr(-,root,root,-)
+%{_libdir}/lib*.so.*
 
 %changelog
+* Mon Nov 22 2021 nephros <sailfish@nephros.org> - 1.6-1
+- version bump
+- do not use packaged oniguruma library
+
 * Thu May 18 2017 rinigus <rinigus.git@gmail.com> - 1.5-1
 - initial packaging release for SFOS


### PR DESCRIPTION
 - add some patches (from Gentoo)
 - do not use bundled oniguruma library
 - split out -libs, the binary doesn't need them
 - remove some man/doc files